### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/civo-navigate-demos/wazero-go/host-application/go.mod
+++ b/civo-navigate-demos/wazero-go/host-application/go.mod
@@ -4,6 +4,6 @@ go 1.19
 
 replace wazero/hosthelpers => ../hosthelpers
 
-require github.com/tetratelabs/wazero v1.0.0-pre.7 // indirect
+require github.com/tetratelabs/wazero v1.0.1 // indirect
 
-require wazero/hosthelpers v0.0.0-00010101000000-000000000000 // indirect
+require wazero/hosthelpers v0.0.0-00010101000000-000000000000

--- a/civo-navigate-demos/wazero-go/host-application/go.sum
+++ b/civo-navigate-demos/wazero-go/host-application/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
-github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/civo-navigate-demos/wazero-go/host-nano-service/go.mod
+++ b/civo-navigate-demos/wazero-go/host-nano-service/go.mod
@@ -4,6 +4,6 @@ go 1.19
 
 replace wazero/hosthelpers => ../hosthelpers
 
-require github.com/tetratelabs/wazero v1.0.0-pre.7
+require github.com/tetratelabs/wazero v1.0.1 // indirect
 
-require wazero/hosthelpers v0.0.0-00010101000000-000000000000 // indirect
+require wazero/hosthelpers v0.0.0-00010101000000-000000000000

--- a/civo-navigate-demos/wazero-go/host-nano-service/go.sum
+++ b/civo-navigate-demos/wazero-go/host-nano-service/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
-github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/civo-navigate-demos/wazero-go/hosthelpers/go.mod
+++ b/civo-navigate-demos/wazero-go/hosthelpers/go.mod
@@ -1,3 +1,5 @@
 module wazero/hosthelpers
 
 go 1.19
+
+require github.com/tetratelabs/wazero v1.0.1

--- a/civo-navigate-demos/wazero-go/hosthelpers/helpers.go
+++ b/civo-navigate-demos/wazero-go/hosthelpers/helpers.go
@@ -50,15 +50,13 @@ func LoadWasmFile(wasmFilePath string) ([]byte, error) {
 func InstantiateWasmModule(wasmRuntime wazero.Runtime, ctx context.Context, wasmFile []byte) (api.Module, error) {
 
 	// Instantiate the WebAssembly module
-	wasmModule, err := wasmRuntime.InstantiateModuleFromBinary(ctx, wasmFile)
+	wasmModule, err := wasmRuntime.Instantiate(ctx, wasmFile)
 	if err != nil {
 		//log.Panicln(err)
 		return nil, err
 	}
 	return wasmModule, nil
 }
-
-
 
 func CopyBufferParameterToMemory(wasmModule api.Module, ctx context.Context, param []byte) (uint64, uint64, error) {
 	paramSize := uint64(len(param))

--- a/civo-navigate-demos/wazero-go/wasm-module/go.mod
+++ b/civo-navigate-demos/wazero-go/wasm-module/go.mod
@@ -4,4 +4,4 @@ go 1.19
 
 replace wazero/wasmhelpers => ../wasmhelpers
 
-require wazero/wasmhelpers v0.0.0-00010101000000-000000000000 // indirect
+require wazero/wasmhelpers v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.